### PR TITLE
Add a default-color for tmux

### DIFF
--- a/lib/thyme/config.rb
+++ b/lib/thyme/config.rb
@@ -3,13 +3,14 @@ module Thyme
     CONFIG_FILE = "#{ENV['HOME']}/.thymerc"
     PID_FILE = "#{ENV['HOME']}/.thyme-pid"
     TMUX_FILE = "#{ENV['HOME']}/.thyme-tmux"
-    OPTIONS = [:break_color, :interval, :timer, :timer_break, :tmux, :tmux_theme, :warning, :warning_color]
+    OPTIONS = [:default_color, :break_color, :interval, :timer, :timer_break, :tmux, :tmux_theme, :warning, :warning_color]
     OPTIONS.each { |opt| attr_reader(opt) }
     attr_accessor :break, :daemon, :repeat, :repeat_index
 
     def initialize
       # options set via config file
       @break_color = 'default'
+      @default_color = 'default'
       @interval = 1
       @timer = 25 * 60
       @timer_break = 5 * 60

--- a/lib/thyme/format.rb
+++ b/lib/thyme/format.rb
@@ -34,7 +34,7 @@ module Thyme
       elsif seconds < @config.warning
         @config.warning_color
       else
-        'default'
+        @config.default_color
       end
     end
   end


### PR DESCRIPTION
Allow setting a `default_color` for tmux instead of using `'default'`. The default color can be set to blend into the existing statusline.
